### PR TITLE
Add LM Studio provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ IBM_PROJECT_ID=
 GROK_ENDPOINT="https://api.x.ai/v1"
 GROK_API_KEY=
 
+LMSTUDIO_ENDPOINT=http://localhost:1234/v1
+LMSTUDIO_API_KEY=
+
 #set default LLM
 DEFAULT_LLM=openai
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We would like to officially thank [WarmShao](https://github.com/warmshao) for hi
 
 **WebUI:** is built on Gradio and supports most of `browser-use` functionalities. This UI is designed to be user-friendly and enables easy interaction with the browser agent.
 
-**Expanded LLM Support:** We've integrated support for various Large Language Models (LLMs), including: Google, OpenAI, Azure OpenAI, Anthropic, DeepSeek, Ollama etc. And we plan to add support for even more models in the future.
+**Expanded LLM Support:** We've integrated support for various Large Language Models (LLMs), including: Google, OpenAI, Azure OpenAI, Anthropic, DeepSeek, Ollama, LM Studio etc. And we plan to add support for even more models in the future.
 
 **Custom Browser Support:** You can use your own browser with our tool, eliminating the need to re-login to sites or deal with other authentication challenges. This feature also supports high-definition screen recording.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - DEEPSEEK_ENDPOINT=${DEEPSEEK_ENDPOINT:-https://api.deepseek.com}
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
       - OLLAMA_ENDPOINT=${OLLAMA_ENDPOINT:-http://localhost:11434}
+      - LMSTUDIO_ENDPOINT=${LMSTUDIO_ENDPOINT:-http://localhost:1234/v1}
+      - LMSTUDIO_API_KEY=${LMSTUDIO_API_KEY:-}
       - MISTRAL_ENDPOINT=${MISTRAL_ENDPOINT:-https://api.mistral.ai/v1}
       - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
       - ALIBABA_ENDPOINT=${ALIBABA_ENDPOINT:-https://dashscope.aliyuncs.com/compatible-mode/v1}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langchain-ibm==0.3.10
 langchain_mcp_adapters==0.0.9
 langgraph==0.3.34
 langchain-community
+python-dotenv

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -9,6 +9,7 @@ PROVIDER_DISPLAY_NAMES = {
     "unbound": "Unbound AI",
     "ibm": "IBM",
     "grok": "Grok",
+    "lmstudio": "LM Studio",
 }
 
 # Predefined model names for common providers
@@ -34,6 +35,9 @@ model_names = {
         "grok-2-vision",
         "grok-2-image",
         "grok-2",
+    ],
+    "lmstudio": [
+        "qwq-32b@4bit",
     ],
     "siliconflow": [
         "deepseek-ai/DeepSeek-R1",

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -7,6 +7,7 @@ from langchain_core.language_models.base import (
     LangSmithParams,
     LanguageModelInput,
 )
+from langchain_core.language_models.chat_models import BaseChatModel
 import os
 from langchain_core.load import dumpd, dumps
 from langchain_core.messages import (
@@ -30,6 +31,8 @@ from langchain_ollama import ChatOllama
 from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.utils.function_calling import convert_to_openai_tool
 
 from typing import (
     TYPE_CHECKING,
@@ -38,7 +41,10 @@ from typing import (
     Literal,
     Optional,
     Union,
-    cast, List,
+    cast,
+    List,
+    Sequence,
+    Iterator,
 )
 from langchain_anthropic import ChatAnthropic
 from langchain_mistralai import ChatMistralAI
@@ -149,6 +155,100 @@ class DeepSeekR1ChatOllama(ChatOllama):
         return AIMessage(content=content, reasoning_content=reasoning_content)
 
 
+class LMStudioChatModel(BaseChatModel):
+    """Minimal chat model for LM Studio using OpenAI-compatible API."""
+
+    model_name: str
+    temperature: float
+    base_url: str
+    api_key: str
+
+    def __init__(self, model: str = "qwq-32b@4bit", temperature: float = 0.0,
+                 base_url: Optional[str] = None, api_key: Optional[str] = None) -> None:
+        self.model_name = model
+        self.temperature = temperature
+        self.base_url = base_url or os.getenv("LMSTUDIO_ENDPOINT", "http://localhost:1234/v1")
+        self.api_key = api_key or os.getenv("LMSTUDIO_API_KEY", "lmstudio")
+        self.client = OpenAI(base_url=self.base_url, api_key=self.api_key)
+
+    def _format_messages(self, messages: list[BaseMessage]) -> list[dict]:
+        formatted = []
+        for m in messages:
+            if isinstance(m, SystemMessage):
+                formatted.append({"role": "system", "content": m.content})
+            elif isinstance(m, AIMessage):
+                formatted.append({"role": "assistant", "content": m.content})
+            elif isinstance(m, HumanMessage):
+                formatted.append({"role": "user", "content": m.content})
+            else:
+                formatted.append({"role": "user", "content": m.content})
+        return formatted
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        payload = {
+            "model": self.model_name,
+            "messages": self._format_messages(messages),
+            "temperature": self.temperature,
+        }
+        if stop:
+            payload["stop"] = stop
+        payload.update(kwargs)
+        response = self.client.chat.completions.create(**payload)
+        message = response.choices[0].message
+        ai_msg = AIMessage(content=message.content or "")
+        if message.tool_calls:
+            ai_msg.additional_kwargs = {
+                "tool_calls": [tc.model_dump() for tc in message.tool_calls]
+            }
+        return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        payload = {
+            "model": self.model_name,
+            "messages": self._format_messages(messages),
+            "temperature": self.temperature,
+            "stream": True,
+        }
+        if stop:
+            payload["stop"] = stop
+        payload.update(kwargs)
+        for chunk in self.client.chat.completions.create(**payload):
+            delta = chunk.choices[0].delta
+            content = delta.content or ""
+            yield ChatGenerationChunk(message=AIMessageChunk(content=content))
+
+    def bind_tools(
+        self,
+        tools: Sequence[Union[dict, type, Callable, BaseTool]],
+        *,
+        tool_choice: Optional[Union[dict, str, Literal["auto", "none", "required", "any"], bool]] = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        formatted_tools = [convert_to_openai_tool(t) for t in tools]
+        tool_names = [t.get("function", {}).get("name") for t in formatted_tools]
+        if tool_choice:
+            if isinstance(tool_choice, str):
+                if tool_choice in tool_names:
+                    tool_choice = {"type": "function", "function": {"name": tool_choice}}
+                elif tool_choice == "any":
+                    tool_choice = "required"
+            elif isinstance(tool_choice, bool):
+                tool_choice = "required"
+            kwargs["tool_choice"] = tool_choice
+        return self.bind(tools=formatted_tools, **kwargs)
+
 def get_llm_model(provider: str, **kwargs):
     """
     Get LLM model
@@ -156,7 +256,7 @@ def get_llm_model(provider: str, **kwargs):
     :param kwargs:
     :return:
     """
-    if provider not in ["ollama", "bedrock"]:
+    if provider not in ["ollama", "bedrock", "lmstudio"]:
         env_var = f"{provider.upper()}_API_KEY"
         api_key = kwargs.get("api_key", "") or os.getenv(env_var, "")
         if not api_key:
@@ -216,6 +316,13 @@ def get_llm_model(provider: str, **kwargs):
             temperature=kwargs.get("temperature", 0.0),
             base_url=base_url,
             api_key=api_key,
+        )
+    elif provider == "lmstudio":
+        return LMStudioChatModel(
+            model=kwargs.get("model_name", "qwq-32b@4bit"),
+            temperature=kwargs.get("temperature", 0.0),
+            base_url=kwargs.get("base_url", os.getenv("LMSTUDIO_ENDPOINT", "http://localhost:1234/v1")),
+            api_key=kwargs.get("api_key", os.getenv("LMSTUDIO_API_KEY", "lmstudio")),
         )
     elif provider == "deepseek":
         if not kwargs.get("base_url", ""):

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -44,7 +44,8 @@ def get_env_value(key, provider):
         "mistral": {"api_key": "MISTRAL_API_KEY", "base_url": "MISTRAL_ENDPOINT"},
         "alibaba": {"api_key": "ALIBABA_API_KEY", "base_url": "ALIBABA_ENDPOINT"},
         "moonshot": {"api_key": "MOONSHOT_API_KEY", "base_url": "MOONSHOT_ENDPOINT"},
-        "ibm": {"api_key": "IBM_API_KEY", "base_url": "IBM_ENDPOINT"}
+        "ibm": {"api_key": "IBM_API_KEY", "base_url": "IBM_ENDPOINT"},
+        "lmstudio": {"api_key": "LMSTUDIO_API_KEY", "base_url": "LMSTUDIO_ENDPOINT"}
     }
 
     if provider in env_mappings and key in env_mappings[provider]:


### PR DESCRIPTION
## Summary
- support `lmstudio` provider with default model `qwq-32b@4bit`
- list LM Studio in provider mappings and README
- expose LM Studio env vars in `.env.example` and `docker-compose.yml`
- update tests to use new variables
- add minimal `LMStudioChatModel` implementation using BaseChatModel
- include `python-dotenv` in requirements

## Testing
- `pytest -q` *(fails: OpenAI, Google, and other API key errors)*

------
https://chatgpt.com/codex/tasks/task_e_68401666c070832fbdcb1a4669279d54